### PR TITLE
11.0 fix purchase request extension ODOO-1685

### DIFF
--- a/purchase_request_extension/models/purchase_request.py
+++ b/purchase_request_extension/models/purchase_request.py
@@ -96,7 +96,7 @@ class PurchaseRequestLine(models.Model):
         string="Purchase Order",
         compute="_compute_purchase_order_name",
     )
-    product_id_default_code = fields.Char(string="Default Code",compute="_compute_product_id_default_code")
+    product_id_default_code = fields.Char(string="Default Code")
 
     @api.depends('purchase_lines')
     def _compute_purchase_order_name(self):
@@ -107,8 +107,8 @@ class PurchaseRequestLine(models.Model):
                 record.purchase_order_name += ' ' + purchase.order_id.name
 
     # Exact copy of the method defined on foreign_purchase_lines.
-    @api.depends('purchase_lines')
-    def _compute_product_id_default_code(self):
+    @api.onchange("product_attr_value_id")
+    def _get_product_id_default_code(self):
         """
         Set the product_id field based in variable option selected
         in the product_attr_value_id (packaging) field
@@ -124,13 +124,10 @@ class PurchaseRequestLine(models.Model):
                     record.product_attr_value_id.id
                     in product.attribute_value_ids.ids
                 ):
-                    record.update(
-                        {
-                            "product_id": product.id,
-                            "product_id_default_code": product.default_code,
-                        }
-                    )
+                    record.product_id = product.id
+                    record.product_id_default_code = product.default_code
                     break
+            return True
     # Exact copy of the method defined on foreign_purchase_lines.
     @api.depends("product_tmpl_id")
     def _available_product_attribute(self):

--- a/purchase_request_extension/models/purchase_request.py
+++ b/purchase_request_extension/models/purchase_request.py
@@ -127,7 +127,6 @@ class PurchaseRequestLine(models.Model):
                     record.product_id = product.id
                     record.product_id_default_code = product.default_code
                     break
-            return True
     # Exact copy of the method defined on foreign_purchase_lines.
     @api.depends("product_tmpl_id")
     def _available_product_attribute(self):

--- a/purchase_request_extension/views/purchase_request_view.xml
+++ b/purchase_request_extension/views/purchase_request_view.xml
@@ -33,6 +33,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
             </field>
             <xpath expr="//field[@name='line_ids']/form//field[@name='product_id']" position="replace">
                 <field name="product_id" force_save="1" invisible="1"/>
+                <field name="product_id_default_code" force_save="1" invisible="1"/>
                 <field name="product_tmpl_id" options="{'no_open':True,'no_create': True, 'no_create_edit':1}" required="1"/>
                 <field name="product_attr_id" invisible="1" />
                 <field name="product_attr_value_id" options="{'no_open':True,'no_create': True,'no_create_edit':1}" 
@@ -40,9 +41,15 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
                        domain="[('product_ids.product_tmpl_id' , '=', product_tmpl_id)]" />
             </xpath>
 
+            <xpath expr="//field[@name='line_ids']/form//field[@name='product_uom_id']" position="attributes">
+                <attribute name="readonly">1</attribute>
+                <attribute name="options">{'no_open':True,'no_create': True,'no_create_edit':1}</attribute>
+            </xpath>
+
             <xpath expr="//field[@name='line_ids']/form//field[@name='purchased_qty']" position="replace">
                 <field name="purchased_qty" string="Quantity in RFQ"/>
             </xpath>
+
 
             <!-- Remove the required date from the lines, as we pass it as an only value on the PR. -->
             <xpath expr="//field[@name='line_ids']/tree//field[@name='date_required']" position="attributes">


### PR DESCRIPTION
Fixed _(guardar y nuevo) button by modifying method and decorator
Made product_uom_field read_only... to avoid possible inconsistent purchase requests 