### PR TITLE
11.0 purchase order bank account rework ODOO-1758

### DIFF
--- a/foreign_purchase_order/README.rst
+++ b/foreign_purchase_order/README.rst
@@ -1,6 +1,6 @@
-=============
+=============================
 Purchase Order Foreign Fields
-=============
+=============================
 
 .. !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    !! This file is intended to be in every module    !!
@@ -71,7 +71,9 @@ Contributors
   
   * Jhone Mendez
   * Federico Gregori
-  * Lucas Soto
+  * Cristian Paradiso
+  * Andres Andrade
+  * Marco Oegg
 
 Maintainers
 ~~~~~~~~~~~

--- a/foreign_purchase_order/__manifest__.py
+++ b/foreign_purchase_order/__manifest__.py
@@ -11,7 +11,7 @@
     "website": "http://odoo.calyx-cloud.com.ar/",
     "license": "AGPL-3",
     "category": "Purchase",
-    "version": "11.0.4.1.1",
+    "version": "11.0.4.2.0",
     "development_status": "Production/Stable",
     "application": False,
     "installable": True,

--- a/foreign_purchase_order/i18n/es_AR.po
+++ b/foreign_purchase_order/i18n/es_AR.po
@@ -1294,3 +1294,13 @@ msgstr "Notas"
 #: model:ir.ui.view,arch_db:foreign_purchase_order.purchase_order_form_foreign_fields
 msgid "Booking(Ship Reserve)"
 msgstr "Origen(Reserva de buque)"
+
+#. module: foreign_purchase_order
+#: model:ir.model.fields,field_description:foreign_purchase_order.field_purchase_order_payment_communication
+msgid "Payment Concept / Request"
+msgstr "Nro de Solicitud / Concepto de Pago"
+
+#. module: foreign_purchase_order
+#: model:ir.model.fields,field_description:foreign_purchase_order.field_purchase_order_payment_bank_and_account
+msgid "Bank and Account"
+msgstr "Banco y Cuenta"

--- a/foreign_purchase_order/models/purchase_order.py
+++ b/foreign_purchase_order/models/purchase_order.py
@@ -113,6 +113,9 @@ class PurchaseOrder(models.Model):
         for rec in self:            
             payment_tte_amount = 0
             payment_application_numbers = ''
+            payment_bank_and_account = ''
+            payment_journal_type = ''
+            payment_communication = ''
             payment_date = ''
             payment_reference = ''
             payment_concept = []
@@ -139,10 +142,21 @@ class PurchaseOrder(models.Model):
                         payment_TC += (str(payment_line.amount) + ' ')
                         payment_TC += (str(payment_line.currency_id.name) + ' - ')
                         payment_TC += ('T/C ' + str(payment_line.exchange_rate) + '\r' + '\n')
-                       
+
+                
+                payment_ids = invoice.payment_ids
+                for payment_id in payment_ids:
+                    payment_bank_and_account += (payment_id.journal_id.name + '  ')
+                    payment_journal_type += (payment_id.journal_id.type + ' ')
+                    if payment_id.communication:
+                        payment_communication += (payment_id.communication + '  ')
+
             rec.payment_application_number = payment_application_numbers
             rec.payment_TTE_amount = payment_tte_amount
             rec.payment_date = payment_date
+            rec.payment_journal_type = payment_journal_type
+            rec.payment_bank_and_account = payment_bank_and_account
+            rec.payment_communication = payment_communication
             rec.payment_reference = payment_reference
             rec.payment_concept = rec._get_invoices_list(payment_concept)
             rec.payment_currency = rec._get_currency_payment_list(payment_currency)
@@ -237,10 +251,10 @@ class PurchaseOrder(models.Model):
     proforma_not_required = fields.Boolean(string="Proforma Not Required")
 
     payment_bank = fields.Char(string="Payment Bank", compute="_get_partner_default_bank")
-    bank_and_account = fields.Char(string="Bank and Account",related="invoice_ids.payment_ids.journal_id.name")
-    journal_type = fields.Selection(string="Journal Type", related="invoice_ids.payment_ids.journal_id.type")
+    payment_bank_and_account = fields.Char(string="Bank and Account", compute="_compute_payment_fields")
+    payment_journal_type = fields.Char(string = 'Is Journal a Bank', compute="_compute_payment_fields")
     payment_account = fields.Char(string="Payment Account", compute="_get_account_bank")
-    concept_and_request= fields.Char(string="Payment Concept / Request", related="invoice_ids.payment_ids.communication")
+    payment_communication = fields.Char(string="Payment Concept / Request", compute="_compute_payment_fields")
     payment_application_number = fields.Char(string="Payment Application number", compute="_compute_payment_fields")
     payment_date = fields.Char(string="Payment Date", compute="_compute_payment_fields")
     payment_reference = fields.Char(string="Payment Reference", compute="_compute_payment_fields")

--- a/foreign_purchase_order/models/purchase_order.py
+++ b/foreign_purchase_order/models/purchase_order.py
@@ -71,11 +71,15 @@ class PurchaseOrder(models.Model):
     )
 
     def _get_partner_default_bank(self):
-        self.payment_bank = self.partner_id.default_bank.bank_id.name
-
+        #self.payment_bank = self.partner_id.default_bank.bank_id.name
+        self.payment_bank = self.invoice_ids.payment_ids.journal_id
+        #invoice_ids.payment_ids.journal_id
+        #invoice_ids.partner_bank_id.acc_number no era
+        
     def _get_account_bank(self):
-        self.payment_account = self.partner_id.default_bank.acc_number
-
+        self.payment_account = self.invoice_ids.payment_ids.communication
+        #invoice_ids.payment_ids.communication
+        #partner_id.default_bank.acc_number
 
     def _get_currency_payment_list(self, list_currency):
         """ It returns the elements of the 
@@ -237,6 +241,7 @@ class PurchaseOrder(models.Model):
     proforma_not_required = fields.Boolean(string="Proforma Not Required")
 
     payment_bank = fields.Char(string="Payment Bank", compute="_get_partner_default_bank")
+    #payment_bank = fields.Many2one(string="Payment Bank",comodel_name="")
     payment_account = fields.Char(string="Payment Account", compute="_get_account_bank")
     payment_application_number = fields.Char(string="Payment Application number", compute="_compute_payment_fields")
     payment_date = fields.Char(string="Payment Date", compute="_compute_payment_fields")

--- a/foreign_purchase_order/models/purchase_order.py
+++ b/foreign_purchase_order/models/purchase_order.py
@@ -70,16 +70,21 @@ class PurchaseOrder(models.Model):
         default=lambda self: str(datetime.today().isocalendar()[1])
     )
 
-    def _get_partner_default_bank(self):
-        #self.payment_bank = self.partner_id.default_bank.bank_id.name
-        self.payment_bank = self.invoice_ids.payment_ids.journal_id
-        #invoice_ids.payment_ids.journal_id
+    # @api.multi
+    # def _get_partner_default_bank(self):
+    #     self.payment_bank = self.partner_id.default_bank.bank_id.name
+    #     res = ""
+    #     for x in self.invoice_ids:
+    #         for y in x.payment_ids:
+    #             res += "/ %s"%(x.journal_id.id)
+    #     self.payment_bank = res
+        #invoice_ids.payment_ids.journal_id.id
         #invoice_ids.partner_bank_id.acc_number no era
         
-    def _get_account_bank(self):
-        self.payment_account = self.invoice_ids.payment_ids.communication
-        #invoice_ids.payment_ids.communication
-        #partner_id.default_bank.acc_number
+    # def _get_account_bank(self):
+    #     self.payment_account = self.partner_id.default_bank.acc_number
+    #     #invoice_ids.payment_ids.communication
+    #     #partner_id.default_bank.acc_number
 
     def _get_currency_payment_list(self, list_currency):
         """ It returns the elements of the 
@@ -240,9 +245,10 @@ class PurchaseOrder(models.Model):
     proforma_date = fields.Date(string="Proforma Date")
     proforma_not_required = fields.Boolean(string="Proforma Not Required")
 
-    payment_bank = fields.Char(string="Payment Bank", compute="_get_partner_default_bank")
-    #payment_bank = fields.Many2one(string="Payment Bank",comodel_name="")
-    payment_account = fields.Char(string="Payment Account", compute="_get_account_bank")
+    #payment_bank = fields.Char(string="Payment Bank", compute="_get_partner_default_bank")
+    payment_bank = fields.Char(string="Payment Bank",related="invoice_ids.payment_ids.journal_id.name")
+    #payment_account = fields.Char(string="Payment Account", compute="_get_account_bank")
+    payment_account = fields.Char(string="Payment Account", related="invoice_ids.payment_ids.communication")
     payment_application_number = fields.Char(string="Payment Application number", compute="_compute_payment_fields")
     payment_date = fields.Char(string="Payment Date", compute="_compute_payment_fields")
     payment_reference = fields.Char(string="Payment Reference", compute="_compute_payment_fields")

--- a/foreign_purchase_order/models/purchase_order.py
+++ b/foreign_purchase_order/models/purchase_order.py
@@ -70,21 +70,12 @@ class PurchaseOrder(models.Model):
         default=lambda self: str(datetime.today().isocalendar()[1])
     )
 
-    # @api.multi
-    # def _get_partner_default_bank(self):
-    #     self.payment_bank = self.partner_id.default_bank.bank_id.name
-    #     res = ""
-    #     for x in self.invoice_ids:
-    #         for y in x.payment_ids:
-    #             res += "/ %s"%(x.journal_id.id)
-    #     self.payment_bank = res
-        #invoice_ids.payment_ids.journal_id.id
-        #invoice_ids.partner_bank_id.acc_number no era
+    def _get_partner_default_bank(self):
+       self.payment_bank = self.partner_id.default_bank.bank_id.name
         
-    # def _get_account_bank(self):
-    #     self.payment_account = self.partner_id.default_bank.acc_number
-    #     #invoice_ids.payment_ids.communication
-    #     #partner_id.default_bank.acc_number
+    def _get_account_bank(self):
+         self.payment_account = self.partner_id.default_bank.acc_number
+
 
     def _get_currency_payment_list(self, list_currency):
         """ It returns the elements of the 
@@ -245,10 +236,10 @@ class PurchaseOrder(models.Model):
     proforma_date = fields.Date(string="Proforma Date")
     proforma_not_required = fields.Boolean(string="Proforma Not Required")
 
-    #payment_bank = fields.Char(string="Payment Bank", compute="_get_partner_default_bank")
-    payment_bank = fields.Char(string="Payment Bank",related="invoice_ids.payment_ids.journal_id.name")
-    #payment_account = fields.Char(string="Payment Account", compute="_get_account_bank")
-    payment_account = fields.Char(string="Payment Account", related="invoice_ids.payment_ids.communication")
+    payment_bank = fields.Char(string="Payment Bank", compute="_get_partner_default_bank")
+    bank_and_account = fields.Char(string="Bank and Account",related="invoice_ids.payment_ids.journal_id.name")
+    payment_account = fields.Char(string="Payment Account", compute="_get_account_bank")
+    concept_and_request= fields.Char(string="Payment Concept / Request", related="invoice_ids.payment_ids.communication")
     payment_application_number = fields.Char(string="Payment Application number", compute="_compute_payment_fields")
     payment_date = fields.Char(string="Payment Date", compute="_compute_payment_fields")
     payment_reference = fields.Char(string="Payment Reference", compute="_compute_payment_fields")

--- a/foreign_purchase_order/models/purchase_order.py
+++ b/foreign_purchase_order/models/purchase_order.py
@@ -238,6 +238,7 @@ class PurchaseOrder(models.Model):
 
     payment_bank = fields.Char(string="Payment Bank", compute="_get_partner_default_bank")
     bank_and_account = fields.Char(string="Bank and Account",related="invoice_ids.payment_ids.journal_id.name")
+    journal_type = fields.Selection(string="Journal Type", related="invoice_ids.payment_ids.journal_id.type")
     payment_account = fields.Char(string="Payment Account", compute="_get_account_bank")
     concept_and_request= fields.Char(string="Payment Concept / Request", related="invoice_ids.payment_ids.communication")
     payment_application_number = fields.Char(string="Payment Application number", compute="_compute_payment_fields")

--- a/foreign_purchase_order/views/purchase_order_view.xml
+++ b/foreign_purchase_order/views/purchase_order_view.xml
@@ -104,10 +104,10 @@
                         <group name="payment" string="Payment">
                             <field name="payment_not_required" type="checkbox" string="Not Required"/>
                             <field name="payment_bank" string="Bank" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>
-                            <field name="bank_and_account" attrs="{'readonly': 1, 'invisible': [('journal_type','!=','bank')]}" force_save="1"/>
-                            <field name="journal_type" invisible= '1'/>
                             <field name="payment_account" string="Account" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>
-                            <field name="concept_and_request" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_journal_type" invisible= '1' force_save="1"/>
+                            <field name="payment_bank_and_account" attrs="{'readonly': 1, 'invisible': [('payment_journal_type','ilike','cash')]}" force_save="1"/>
+                            <field name="payment_communication" attrs="{'readonly': 1}" force_save="1"/>
                             <field name="payment_application_number" string="Application Number" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>
                             <field name="payment_date" string="Date" attrs="{'readonly': 1}" force_save="1"/>
                             <field name="payment_reference" string="Reference" attrs="{'readonly': 1}" force_save="1"/>

--- a/foreign_purchase_order/views/purchase_order_view.xml
+++ b/foreign_purchase_order/views/purchase_order_view.xml
@@ -103,15 +103,15 @@
                         </group>
                         <group name="payment" string="Payment">
                             <field name="payment_not_required" type="checkbox" string="Not Required"/>
-                            <field name="payment_bank" string="Bank" attrs="{'readonly': [('payment_not_required','=',True)]}" force_save="1"/>
-                            <field name="payment_account" string="Account" attrs="{'readonly': [('payment_not_required','=',True)]}" force_save="1"/>
-                            <field name="payment_application_number" string="Application Number" attrs="{'readonly': [('payment_not_required','=',True)]}" force_save="1"/>
-                            <field name="payment_date" string="Date" attrs="{'readonly': [('payment_not_required','=',True)]}" force_save="1"/>
-                            <field name="payment_reference" string="Reference" attrs="{'readonly': [('payment_not_required','=',True)]}" force_save="1"/>
-                            <field name="payment_concept" string="Concept" attrs="{'readonly': [('payment_not_required','=',True)]}" force_save="1"/>
-                            <field name="payment_currency" string="Payment Currency" attrs="{'readonly': [('payment_not_required','=',True)]}" force_save="1"/>
-                            <field name="payment_TTE_amount" string="TTE Paid Value'" attrs="{'readonly': [('payment_not_required','=',True)]}" force_save="1"/>
-                            <field name="payment_TC" string="TC" attrs="{'readonly': [('payment_not_required','=',True)]}" force_save="1"/>
+                            <field name="payment_bank" string="Bank" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_account" string="Account" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_application_number" string="Application Number" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_date" string="Date" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_reference" string="Reference" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_concept" string="Concept" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_currency" string="Payment Currency" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_TTE_amount" string="TTE Paid Value'" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_TC" string="TC" attrs="{'readonly': 1}" force_save="1"/>
                         </group>
                         <group name="dispatcher" string="Dispatcher">
                             <field name="dispatcher_not_required" type="checkbox" string="Not Required"/>

--- a/foreign_purchase_order/views/purchase_order_view.xml
+++ b/foreign_purchase_order/views/purchase_order_view.xml
@@ -104,7 +104,8 @@
                         <group name="payment" string="Payment">
                             <field name="payment_not_required" type="checkbox" string="Not Required"/>
                             <field name="payment_bank" string="Bank" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>
-                            <field name="bank_and_account" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="bank_and_account" attrs="{'readonly': 1, 'invisible': [('journal_type','!=','bank')]}" force_save="1"/>
+                            <field name="journal_type" invisible= '1'/>
                             <field name="payment_account" string="Account" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>
                             <field name="concept_and_request" attrs="{'readonly': 1}" force_save="1"/>
                             <field name="payment_application_number" string="Application Number" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>

--- a/foreign_purchase_order/views/purchase_order_view.xml
+++ b/foreign_purchase_order/views/purchase_order_view.xml
@@ -103,12 +103,14 @@
                         </group>
                         <group name="payment" string="Payment">
                             <field name="payment_not_required" type="checkbox" string="Not Required"/>
-                            <field name="payment_bank" string="Bank" attrs="{'readonly': 1}" force_save="1"/>
-                            <field name="payment_account" string="Account" attrs="{'readonly': 1}" force_save="1"/>
-                            <field name="payment_application_number" string="Application Number" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_bank" string="Bank" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>
+                            <field name="bank_and_account" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_account" string="Account" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>
+                            <field name="concept_and_request" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_application_number" string="Application Number" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>
                             <field name="payment_date" string="Date" attrs="{'readonly': 1}" force_save="1"/>
                             <field name="payment_reference" string="Reference" attrs="{'readonly': 1}" force_save="1"/>
-                            <field name="payment_concept" string="Concept" attrs="{'readonly': 1}" force_save="1"/>
+                            <field name="payment_concept" string="Concept" attrs="{'readonly': 1, 'invisible': 1}" force_save="1"/>
                             <field name="payment_currency" string="Payment Currency" attrs="{'readonly': 1}" force_save="1"/>
                             <field name="payment_TTE_amount" string="TTE Paid Value'" attrs="{'readonly': 1}" force_save="1"/>
                             <field name="payment_TC" string="TC" attrs="{'readonly': 1}" force_save="1"/>


### PR DESCRIPTION
Added 3 new computed fields. payment_bank_and_account, payment_journal_type and payment_communication.
Both are computed with the rest of the fields in _compute_payment_fields() method.
Made payment_bank and payment_account invisible.
Made payment_bank_and_account visible if payment_journal_type is not cash.
Modified README and __manifest__.
Add translations to new visible fields