### PR TITLE
11.0 fix foreign trade buttons ODOO-1789, ODOO-1847

### DIFF
--- a/foreign_trade/l18n/es_AR.po
+++ b/foreign_trade/l18n/es_AR.po
@@ -1326,7 +1326,7 @@ msgstr "Precio de Unidad"
 #. module: foreign_trade
 #: model:ir.ui.view,arch_db:foreign_trade.view_order_form
 msgid "Print Foreign Report"
-msgstr "Imprimir OE"
+msgstr "Print Foreign Report"
 
 #. module: foreign_trade
 #: model:ir.ui.view,arch_db:foreign_trade.view_order_form

--- a/foreign_trade/views/sale_order_view.xml
+++ b/foreign_trade/views/sale_order_view.xml
@@ -15,7 +15,7 @@
                 <attribute name="attrs">{'invisible': ['|',('order_type_foreign','=',True)]}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_quotation_send'][2]" position="attributes">
-                <attribute name="attrs">{'invisible': 1}</attribute>
+                <attribute name="attrs">{'invisible': True}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_quotation_send'][3]" position="attributes">
                 <attribute name="attrs">{'invisible': ['|',('order_type_foreign','=',True)]}</attribute>

--- a/foreign_trade/views/sale_order_view.xml
+++ b/foreign_trade/views/sale_order_view.xml
@@ -15,10 +15,10 @@
                 <attribute name="attrs">{'invisible': ['|',('order_type_foreign','=',True)]}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_quotation_send'][2]" position="attributes">
-                <attribute name="attrs">{'invisible': ['|','|', ('state', '!=', 'draft'), ('invoice_count','&gt;=',1),('order_type_foreign','=',True)]}</attribute>
+                <attribute name="attrs">{'invisible': 1}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_quotation_send'][3]" position="attributes">
-                <attribute name="attrs">{'invisible': ['|','|', ('state', '=', 'draft'), ('invoice_count','&gt;=',1),('order_type_foreign','=',True)]}</attribute>
+                <attribute name="attrs">{'invisible': ['|',('order_type_foreign','=',True)]}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_quotation_send'][4]" position="attributes">
                 <attribute name="attrs">{'invisible': ['|',('order_type_foreign','=',True)]}</attribute>

--- a/foreign_trade/views/sale_order_view.xml
+++ b/foreign_trade/views/sale_order_view.xml
@@ -15,10 +15,10 @@
                 <attribute name="attrs">{'invisible': ['|',('order_type_foreign','=',True)]}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_quotation_send'][2]" position="attributes">
-                <attribute name="attrs">{'invisible': ['|',('order_type_foreign','=',True)]}</attribute>
+                <attribute name="attrs">{'invisible': ['|','|', ('state', '!=', 'draft'), ('invoice_count','&gt;=',1),('order_type_foreign','=',True)]}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_quotation_send'][3]" position="attributes">
-                <attribute name="attrs">{'invisible': ['|',('order_type_foreign','=',True)]}</attribute>
+                <attribute name="attrs">{'invisible': ['|','|', ('state', '=', 'draft'), ('invoice_count','&gt;=',1),('order_type_foreign','=',True)]}</attribute>
             </xpath>
             <xpath expr="//button[@name='action_quotation_send'][4]" position="attributes">
                 <attribute name="attrs">{'invisible': ['|',('order_type_foreign','=',True)]}</attribute>


### PR DESCRIPTION
-modified print foreign report button to not be translated. (making this change to actually apply will probably take several tries, at least it did on test server)
-made one of the buttons invisible (they were supposed to show as class btn-primary if state != draft and no class when otherwise. In some cases that button dissappeared completely if invisible property had the correct clause and it's supposed to be there all the time so I finally just reverted changes and 'deleted' one) 